### PR TITLE
feat: allow CONNECT to non-standard ports via network.allowedPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,25 @@ By default, agents can only reach domains required for their operation (e.g. `ap
 
 Use plain domain names — dots are auto-escaped for the proxy filter. After changing the whitelist, restart the sandbox (changes take effect on next `hole start`).
 
+### Allowed ports
+
+By default the proxy only permits HTTPS `CONNECT` to ports `80` and `443`. To reach a service on another port (e.g. an upstream API on port `2024`), list the ports in `network.allowedPorts`:
+
+```json
+{
+  "network": {
+    "domainWhitelist": ["37.221.253.75"],
+    "allowedPorts": [443, 80, 2024]
+  }
+}
+```
+
+- **The list replaces the defaults.** If you set `allowedPorts`, the built-in `[80, 443]` are dropped — include them yourself if you still need them. This is intentional: it gives you a single, authoritative view of which CONNECT ports the proxy accepts, and lets you lock down port 80 if you want HTTPS-only.
+- **Proxy-global, not per-host.** Tinyproxy applies `ConnectPort` across all whitelisted hosts; there is no way to bind a port to a single host. Adding port `2024` lets any whitelisted host be reached on that port.
+- **Empty array disables CONNECT entirely** (`allowedPorts: []` emits `ConnectPort 0`).
+- **Global / project merge.** Arrays from `~/.hole/settings.json` and `.hole/settings.json` are concatenated and deduplicated before the replace-defaults step is applied.
+- Changes take effect on next `hole start`.
+
 ### Host gateway domains
 
 Allow the agent to reach services running on the Docker host by domain name. Configured domains resolve to the host gateway IP via a CoreDNS container inside the sandbox:

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Use plain domain names — dots are auto-escaped for the proxy filter. After cha
 
 ### Allowed ports
 
-By default the proxy only permits HTTPS `CONNECT` to ports `80` and `443`. To reach a service on another port (e.g. an upstream API on port `2024`), list the ports in `network.allowedPorts`:
+By default the proxy only permits `CONNECT` to ports `80` and `443`. To reach a service on another port (e.g. an upstream API on port `2024`), list the ports in `network.allowedPorts`:
 
 ```json
 {

--- a/hole.sh
+++ b/hole.sh
@@ -616,6 +616,39 @@ generate_instance_compose() {
     done <<< "${host_gateway_domains}"
   fi
 
+  # Generate proxy config with merged ConnectPort list.
+  # If user supplied network.allowedPorts (at global or project level), the merged
+  # list replaces the defaults (80, 443). An empty array disables CONNECT entirely
+  # (emitted as `ConnectPort 0`).
+  local proxy_conf="${HOLE_TMP_DIR}/tinyproxy.conf"
+  local base_proxy_conf
+  if [[ "${unrestricted_network}" == true ]]; then
+    base_proxy_conf="${SCRIPT_DIR}/proxy/tinyproxy-unrestricted.conf"
+  else
+    base_proxy_conf="${SCRIPT_DIR}/proxy/tinyproxy.conf"
+  fi
+  local allowed_ports_set
+  allowed_ports_set=$(echo "${merged_settings}" | jq -r '(.network // {}) | has("allowedPorts")' 2>/dev/null) || allowed_ports_set="false"
+  local allowed_ports
+  allowed_ports=$(echo "${merged_settings}" | jq -r '.network.allowedPorts[]? // empty' 2>/dev/null) || true
+  grep -v -E '^[[:space:]]*ConnectPort[[:space:]]' "${base_proxy_conf}" > "${proxy_conf}"
+  {
+    printf '\n'
+    if [[ "${allowed_ports_set}" == "true" ]]; then
+      if [[ -z "${allowed_ports}" ]]; then
+        echo "ConnectPort 0"
+      else
+        while IFS= read -r port; do
+          [[ -z "${port}" ]] && continue
+          echo "ConnectPort ${port}"
+        done <<< "${allowed_ports}"
+      fi
+    else
+      echo "ConnectPort 443"
+      echo "ConnectPort 80"
+    fi
+  } >> "${proxy_conf}"
+
   # Build CoreDNS Corefile: custom domain blocks + catch-all forward
   local corefile="${HOLE_TMP_DIR}/Corefile"
 
@@ -787,11 +820,7 @@ BLOCK
     echo "      - ${dns_ip}"
     echo "      - 127.0.0.11"
     echo "    volumes:"
-    if [[ "${unrestricted_network}" == true ]]; then
-      echo "      - ${SCRIPT_DIR}/proxy/tinyproxy-unrestricted.conf:/etc/tinyproxy/tinyproxy.conf:ro"
-    else
-      echo "      - ${SCRIPT_DIR}/proxy/tinyproxy.conf:/etc/tinyproxy/tinyproxy.conf:ro"
-    fi
+    echo "      - ${proxy_conf}:/etc/tinyproxy/tinyproxy.conf:ro"
     echo "      - ${HOLE_TMP_DIR}/tinyproxy-domain-whitelist.txt:/etc/tinyproxy/allowed-domains.txt:ro"
     if [[ "${has_host_gateway_domains}" == true ]]; then
       echo "    extra_hosts:"

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -44,6 +44,15 @@
             "minLength": 1,
             "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$"
           }
+        },
+        "allowedPorts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "uniqueItems": true
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds `network.allowedPorts` to `settings.json`, letting users open additional tinyproxy `ConnectPort` entries so agents can reach REST endpoints on non-standard ports (e.g. `:2024`, `:8443`, `:9000`) without dropping all network restrictions via `--unrestricted-network`.

## Business case

Several of our projects expose REST APIs on non-standard ports. With the current sandbox, those calls fail at the proxy even when the host is in `domainWhitelist`, because `proxy/tinyproxy.conf` hardcodes `ConnectPort 80` / `ConnectPort 443`. The only escape was unrestricted networking, which is too coarse.

Closes #29.

## Configuration

```json
{
  "network": {
    "domainWhitelist": ["37.221.253.75"],
    "allowedPorts": [443, 80, 2024]
  }
}
```

### Semantics

- **Replace, not extend.** If `allowedPorts` is set, the merged list replaces the built-in `[80, 443]` defaults. Matches firewall/SG/nginx `listen` conventions and lets users lock down port 80 if they want HTTPS-only.
- **Proxy-global.** Tinyproxy `ConnectPort` is not per-host; adding `2024` makes any whitelisted host reachable on that port. Documented.
- **Empty array** (`[]`) disables CONNECT entirely (emits `ConnectPort 0`).
- **Global / project merge.** Arrays concat + dedup (same as other arrays); replace-defaults applies to the merged result.
- **Backward compatible.** No existing `settings.json` changes behavior.

## Implementation

- `schema/settings.schema.json` — new `network.allowedPorts`: integer array `1..65535`, `uniqueItems: true`.
- `hole.sh` — renders `tinyproxy.conf` into `HOLE_TMP_DIR` per run: strips existing `ConnectPort` lines from the base config and re-emits them based on merged settings. The proxy service mount now points at the generated file (same path swap applies to the `--unrestricted-network` variant).
- `README.md` — new `### Allowed ports` subsection under "Domain whitelist".

## Test plan

- [x] `bash -n hole.sh` — syntax OK.
- [x] Smoke-tested config rendering with four cases: unset, defaults-included, custom-only, empty array — all produced the expected `ConnectPort` lines.
- [ ] Reviewer: start a sandbox with `allowedPorts: [2024]` and verify `curl https://<host>:2024/...` succeeds inside the agent and is rejected when the port is removed.
- [ ] Reviewer: verify `allowedPorts: []` blocks all CONNECT.
- [ ] Reviewer: verify a project without `allowedPorts` still reaches port 443 normally (no regression).