### PR TITLE
feat: run all setup hook scripts, not just the last one to win

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,24 +593,26 @@ If a setupHost script exits with a non-zero status, the sandbox startup is abort
 
 #### Setup hook
 
-Run a custom bash script during the Docker image build to perform system-level setup (install packages, configure locales, add apt repositories, etc.):
+Run custom bash scripts during the Docker image build to perform system-level setup (install packages, configure locales, add apt repositories, etc.):
 
 ```json
 {
   "hooks": {
-    "setup": {
-      "script": ".hole/setup.sh"
-    }
+    "setup": [
+      { "script": ".hole/setup.sh" },
+      { "script": "~/shared-setup.sh" }
+    ]
   }
 }
 ```
 
-The script runs as the agent user during the image build, after dependency installation. Host paths support environment variable expansion (`$VAR`, `${VAR}`), tilde expansion (`~/`), relative paths (resolved against the project directory), and absolute paths. Non-existent paths are skipped with a warning.
+Scripts run as the agent user during the image build, after dependency installation. Passwordless `sudo` is available, so they can install system-wide packages. Host paths support environment variable expansion (`$VAR`, `${VAR}`), tilde expansion (`~/`), relative paths (resolved against the project directory), and absolute paths. Non-existent paths are skipped with a warning.
 
-**Important:** The agent home directory (mirrors host's `$HOME`, e.g., `/Users/me` on macOS) is backed by a persistent Docker volume that overrides image contents.
-Do not install anything to the agent home directory in the setup script — it will be hidden by the volume mount.
+Scripts execute in array order (global settings first, then project settings), and both settings files contribute: a project can add its own build steps without losing the ones defined globally. If a setup script exits with a non-zero status, the image build fails and the remaining scripts do not run.
 
-Use `--rebuild` to force a fresh build if needed.
+**Legacy object form.** A single script can also be configured as `"setup": { "script": ".hole/setup.sh" }`. This form still works, but it is a scalar, so a project value **replaces** the global one instead of merging with it — the global script then never runs. Hole warns when this happens. Use the array form in both files to run all of them.
+
+Use `--rebuild` to force a fresh build if needed — setup scripts only run when the image is actually built.
 
 #### Prestart hook
 

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -71,12 +71,13 @@ RUN for agent_dir in /tmp/agent-installs/*/; do \
       fi; \
     done
 
-## Prepare user setup hook script
+## Prepare user setup hook scripts (numbered by hole.sh, executed in sorted order)
 COPY setup-scripts/ /tmp/setup-scripts/
-RUN if [ -f /tmp/setup-scripts/setup.sh ]; then \
-      chown "${AGENT_USERNAME}" /tmp/setup-scripts/setup.sh && \
-      chmod +x /tmp/setup-scripts/setup.sh; \
-    fi
+RUN set -e; for setup_script in /tmp/setup-scripts/*.sh; do \
+      [ -f "${setup_script}" ] || continue; \
+      chown "${AGENT_USERNAME}" "${setup_script}"; \
+      chmod +x "${setup_script}"; \
+    done
 
 USER ${AGENT_USERNAME}
 
@@ -95,10 +96,13 @@ RUN for agent_dir in /tmp/agent-installs/*/; do \
       fi; \
     done
 
-## Execute User setup hook script
-RUN if [ -f /tmp/setup-scripts/setup.sh ]; then \
-      /tmp/setup-scripts/setup.sh; \
-    fi
+## Execute User setup hook scripts (global settings first, then project settings)
+# set -e: a failing setup script must abort the build, not be masked by a later one
+RUN set -e; for setup_script in /tmp/setup-scripts/*.sh; do \
+      [ -f "${setup_script}" ] || continue; \
+      echo "==> Running setup hook: $(basename "${setup_script}")"; \
+      "${setup_script}"; \
+    done
 
 USER root
 

--- a/documentation/developer/agents.md
+++ b/documentation/developer/agents.md
@@ -52,8 +52,8 @@ Build phases, in order:
    user (`useradd -l` avoids a huge sparse lastlog for very high host UIDs); passwordless sudo.
 7. **User-phase agent installs** run as the agent user, with `BASH_ENV=~/.bash_env` set up so
    tools installed via nvm & co. work in non-interactive shells.
-8. **User setup hook** (`hooks.setup.script`, copied to `setup-scripts/setup.sh`) runs as the
-   agent user; script content changes bust the Docker layer cache.
+8. **User setup hooks** (`hooks.setup`, copied to `setup-scripts/001-name.sh`, `002-name.sh`, ...)
+   run as the agent user in sorted order; script content changes bust the Docker layer cache.
 9. **Entrypoint**: `agents/entrypoint.sh` — runs any mounted `/tmp/prestart-scripts/*` in sorted
    order (numbered `001-`, `002-`, ... prefixes; failure aborts startup), then `exec "$@"` into
    the agent command.

--- a/documentation/developer/configuration.md
+++ b/documentation/developer/configuration.md
@@ -108,15 +108,20 @@ passed to the DinD sidecar when Docker is enabled.
 
 | Hook | Where | When | Runs as | On failure |
 |---|---|---|---|---|
-| `hooks.setup.script` | container (build) | during `docker build`, after agent installs | agent user | aborts build |
+| `hooks.setup[]` | container (build) | during `docker build`, after agent installs | agent user | aborts build |
 | `hooks.prestart[]` | container (runtime) | every start, before the agent CLI (`entrypoint.sh`) | agent user | aborts startup |
 | `hooks.setupHost[]` | host | before any Docker work in `cmd_start` | host user | aborts startup (cleanupHost still runs) |
 | `hooks.cleanupHost[]` | host | teardown phase 5, after Docker teardown | host user | warning only, teardown continues |
 
 Implementation notes:
 
-- `setup.script` is a scalar (project overrides global); the script is copied into the build
-  context as `setup-scripts/setup.sh`, so content changes bust the Docker layer cache.
+- `setup` is an array (global entries first, then project); scripts are copied into the build
+  context as `setup-scripts/001-name.sh`, `002-name.sh`, ... and `agents/Dockerfile` runs them in
+  sorted order under `set -e`. Content changes bust the Docker layer cache.
+  The legacy object form (`"setup": { "script": "..." }`) is still accepted, but it is a scalar,
+  so a project value replaces the global one and the global script never runs —
+  `warn_on_setup_hook_shadowing()` warns whenever the two settings files do not both use the
+  array form.
 - `prestart` is an array (global entries first, then project); scripts are copied to
   `${HOLE_TMP_DIR}/prestart-scripts/` with numbered prefixes (`001-name.sh`, ...) and mounted
   read-only at `/tmp/prestart-scripts/`; `entrypoint.sh` runs them in sorted order.

--- a/hole.sh
+++ b/hole.sh
@@ -183,6 +183,30 @@ merge_settings() {
   '
 }
 
+# Warn when a project setup hook silently replaces the global one. In the legacy
+# object form hooks.setup is a scalar as far as deep_merge is concerned, so the
+# project value wins and the global script never runs. The array form merges.
+warn_on_setup_hook_shadowing() {
+  local global_file="${1}"
+  local project_file="${2}"
+
+  [[ -f "${global_file}" && -f "${project_file}" ]] || return 0
+  require_cmd "jq"
+
+  local global_type
+  global_type=$(jq -r '.hooks.setup | type' "${global_file}" 2>/dev/null) || return 0
+  local project_type
+  project_type=$(jq -r '.hooks.setup | type' "${project_file}" 2>/dev/null) || return 0
+
+  # Only two arrays merge; any other combination lets the project value replace
+  # the global one entirely.
+  if [[ "${global_type}" != "null" && "${project_type}" != "null" ]] \
+     && [[ "${global_type}" != "array" || "${project_type}" != "array" ]]; then
+    log_warn "project hooks.setup replaces the global one, so the setup script(s) from ~/.hole/settings.json will NOT run"
+    log_warn "use the array form ('\"setup\": [{ \"script\": \"...\" }]') in both files to run all setup scripts"
+  fi
+}
+
 # Resolve project directory to absolute path
 resolve_absolute_project_dir() {
   local target_dir="${1:-.}"
@@ -722,18 +746,38 @@ BLOCK
   local base_image
   base_image=$(echo "${merged_settings}" | jq -r '.container.baseImage // empty' 2>/dev/null) || true
 
-  # Read setup hook script from merged settings
-  local setup_script_path
-  setup_script_path=$(echo "${merged_settings}" | jq -r '.hooks.setup.script // empty' 2>/dev/null) || true
-  local has_setup_script=false
+  # Read setup hook scripts from merged settings.
+  # Accepts both the array form (global and project scripts are merged and all
+  # of them run) and the legacy object form (a single script; a project value
+  # replaces the global one).
+  local setup_scripts
+  setup_scripts=$(echo "${merged_settings}" | jq -r '
+    (.hooks.setup // empty) as $setup
+    | if ($setup | type) == "array" then $setup[].script // empty
+      else $setup.script // empty
+      end' 2>/dev/null) || true
 
-  if [[ -n "${setup_script_path}" ]]; then
-    setup_script_path=$(resolve_host_path "${setup_script_path}" "${project_dir}")
-    if [[ -f "${setup_script_path}" ]]; then
-      has_setup_script=true
-    else
-      log_warn "setup hook script '${setup_script_path}' not found, skipping"
-    fi
+  # Always create setup-scripts dir in temp (even if empty) so Dockerfile COPY works
+  mkdir -p "${HOLE_TMP_DIR}/setup-scripts"
+  touch "${HOLE_TMP_DIR}/setup-scripts/.gitkeep"
+
+  if [[ -n "${setup_scripts}" ]]; then
+    local setup_index=0
+    while IFS= read -r setup_script_path; do
+      [[ -z "${setup_script_path}" ]] && continue
+      setup_script_path=$(resolve_host_path "${setup_script_path}" "${project_dir}")
+      if [[ -f "${setup_script_path}" ]]; then
+        setup_index=$((setup_index + 1))
+        local setup_basename
+        setup_basename=$(basename "${setup_script_path}")
+        local setup_dest
+        setup_dest=$(printf "%03d-%s" "${setup_index}" "${setup_basename}")
+        cp "${setup_script_path}" "${HOLE_TMP_DIR}/setup-scripts/${setup_dest}"
+        chmod +x "${HOLE_TMP_DIR}/setup-scripts/${setup_dest}"
+      else
+        log_warn "setup hook script '${setup_script_path}' not found, skipping"
+      fi
+    done <<< "${setup_scripts}"
   fi
 
   # Read prestart hook scripts from merged settings
@@ -771,13 +815,6 @@ BLOCK
   # Copy entrypoint.sh to build context
   mkdir -p "${HOLE_TMP_DIR}"
   cp "${SCRIPT_DIR}/agents/entrypoint.sh" "${HOLE_TMP_DIR}/entrypoint.sh"
-
-  # Always create setup-scripts dir in temp (even if empty) so Dockerfile COPY works
-  mkdir -p "${HOLE_TMP_DIR}/setup-scripts"
-  touch "${HOLE_TMP_DIR}/setup-scripts/.gitkeep"
-  if [[ "${has_setup_script}" == true ]]; then
-    cp "${setup_script_path}" "${HOLE_TMP_DIR}/setup-scripts/setup.sh"
-  fi
 
   # Copy enabled agents' install scripts to build context
   mkdir -p "${HOLE_TMP_DIR}/agent-installs"
@@ -1130,6 +1167,7 @@ cmd_start() {
   validate_settings "${project_dir}/.hole/settings.json" "project settings (.hole/settings.json)"
 
   # Merge global and project settings
+  warn_on_setup_hook_shadowing "${GLOBAL_SETTINGS_FILE}" "${project_dir}/.hole/settings.json"
   local merged_settings
   merged_settings=$(merge_settings "${GLOBAL_SETTINGS_FILE}" "${project_dir}/.hole/settings.json")
 

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -94,14 +94,32 @@
       "additionalProperties": false,
       "properties": {
         "setup": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "script": {
-              "type": "string",
-              "minLength": 1
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "script": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["script"]
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "script": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
-          }
+          ]
         },
         "prestart": {
           "type": "array",

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -117,7 +117,8 @@
                   "type": "string",
                   "minLength": 1
                 }
-              }
+              },
+              "required": ["script"]
             }
           ]
         },


### PR DESCRIPTION
## What was wrong

`hooks.setup` was an object (`{ "script": "..." }`). For `deep_merge` an object with scalar values behaves like a scalar: the project value wins and the global value is dropped. `hooks.prestart` and `hooks.setupHost` are arrays and merge properly, so the two neighbouring features behaved in opposite ways.

### The setup that hit this

A real configuration that ran into it:

- `~/.hole/settings.json` defined a global setup script installing personal tooling into every sandbox — Maven, Node via nvm, `rtk`, `jdtls`, and (newly added) the GitHub CLI.
- Five project repositories each defined their own `.hole/setup.sh`, installing a project-specific Maven version.

Because both used the object form, the project script replaced the global one. In those five projects the global setup script had never run — not once.

### Why it was hard to see

Nothing failed. The image build succeeded, and inside the container `mvn --version` reported a perfectly plausible Maven — the *project's* Maven. The setup hook had clearly run, just not the one the user was editing. Only tools unique to the global script (`gh`, `rtk`, `jdtls`) were missing, with no warning anywhere pointing at the dropped configuration. The failure was indistinguishable from success.

## What changed

- **`hooks.setup` accepts an array** of `{script}` entries, merged global-first then project, exactly like `hooks.prestart`. Both settings files now contribute.
- **Scripts are numbered** (`001-name.sh`, `002-name.sh`, ...) when copied into the build context, so scripts sharing a basename (the common `.hole/setup.sh` case) no longer collide.
- **`agents/Dockerfile` iterates** the setup-scripts directory in sorted order under `set -e`, so a failing script aborts the build instead of being masked by a later one. Previously a single fixed `setup.sh` was executed.
- **The object form still works** for backwards compatibility, and `warn_on_setup_hook_shadowing()` warns at startup whenever the global and project settings do not both use the array form — the silent case is now loud.
- **Schema** allows both forms (`oneOf`), so existing configurations keep validating.
- **Docs** updated: README setup hook section, `documentation/developer/configuration.md`, `documentation/developer/agents.md`. The README also lost a stale warning about the agent home directory being backed by a persistent volume — that volume was removed in `feat!: reimplement agent sandbox home directory`, so setup scripts *can* install into `$HOME`.

## New configuration shape

```json
{
  "hooks": {
    "setup": [
      { "script": "~/.hole/setup.sh" },
      { "script": ".hole/setup.sh" }
    ]
  }
}
```

## Verification

- JSON schema validated against fixtures: array form, legacy object form, and two malformed variants (rejected).
- Setting extraction checked for array form, object form, and settings with no `hooks.setup`.
- `merge_settings` + the new warning exercised across all five combinations (array+array merges silently; array+object, object+array and object+object warn; project without `hooks.setup` stays quiet).
- The script-copying block run against fixtures: two scripts both named `setup.sh` land as `001-setup.sh`/`002-setup.sh` in the right order with the executable bit set, and a missing path warns and is skipped.
- The Dockerfile loop exercised with real `docker build` runs: ordered execution, `.gitkeep` ignored, empty directory builds fine, and a failing first script aborts the build (exit code propagated, second script not reached) — including a run where the build context was the output of the `hole.sh` block above.
- No full `hole start --rebuild` against a real agent image was run.